### PR TITLE
refactor: move `push` variables out of `super()`

### DIFF
--- a/base32.ts
+++ b/base32.ts
@@ -10,21 +10,21 @@ import { decodeBase32, encodeBase32 } from '@std/encoding/base32'
  */
 export class EncodeBase32Stream extends TransformStream<Uint8Array, string> {
 	constructor() {
+		let push = new Uint8Array(0)
 		super({
-			push: new Uint8Array(0),
 			transform(chunk, controller) {
-				const concat = new Uint8Array(this.push.length + chunk.length)
-				concat.set(this.push)
-				concat.set(chunk, this.push.length)
+				const concat = new Uint8Array(push.length + chunk.length)
+				concat.set(push)
+				concat.set(chunk, push.length)
 
 				const remainder = -concat.length % 5
 				controller.enqueue(encodeBase32(concat.slice(0, remainder || undefined)))
-				this.push = remainder ? concat.slice(remainder) : new Uint8Array(0)
+				push = remainder ? concat.slice(remainder) : new Uint8Array(0)
 			},
 			flush(controller) {
-				controller.enqueue(encodeBase32(this.push))
+				controller.enqueue(encodeBase32(push))
 			},
-		} as Transformer<Uint8Array, string> & { push: Uint8Array })
+		})
 	}
 }
 
@@ -33,16 +33,16 @@ export class EncodeBase32Stream extends TransformStream<Uint8Array, string> {
  */
 export class DecodeBase32Stream extends TransformStream<string, Uint8Array> {
 	constructor() {
+		let push = ''
 		super({
-			push: '',
 			transform(chunk, controller) {
-				const remainder = -(this.push.length + chunk.length) % 8
-				controller.enqueue(decodeBase32(this.push + chunk.slice(0, remainder || undefined)))
-				this.push = remainder ? chunk.slice(remainder) : ''
+				const remainder = -(push.length + chunk.length) % 8
+				controller.enqueue(decodeBase32(push + chunk.slice(0, remainder || undefined)))
+				push = remainder ? chunk.slice(remainder) : ''
 			},
 			flush(controller) {
-				if (this.push.length) controller.enqueue(decodeBase32(this.push))
+				if (push.length) controller.enqueue(decodeBase32(push))
 			},
-		} as Transformer<string, Uint8Array> & { push: string })
+		})
 	}
 }

--- a/base64url.ts
+++ b/base64url.ts
@@ -10,21 +10,21 @@ import { decodeBase64Url, encodeBase64Url } from '@std/encoding/base64url'
  */
 export class EncodeBase64UrlStream extends TransformStream<Uint8Array, string> {
 	constructor() {
+		let push = new Uint8Array(0)
 		super({
-			push: new Uint8Array(0),
 			transform(chunk, controller) {
-				const concat = new Uint8Array(this.push.length + chunk.length)
-				concat.set(this.push)
-				concat.set(chunk, this.push.length)
+				const concat = new Uint8Array(push.length + chunk.length)
+				concat.set(push)
+				concat.set(chunk, push.length)
 
 				const remainder = -concat.length % 3
 				controller.enqueue(encodeBase64Url(concat.slice(0, remainder || undefined)))
-				this.push = remainder ? concat.slice(remainder) : new Uint8Array(0)
+				push = remainder ? concat.slice(remainder) : new Uint8Array(0)
 			},
 			flush(controller) {
-				controller.enqueue(encodeBase64Url(this.push))
+				controller.enqueue(encodeBase64Url(push))
 			},
-		} as Transformer<Uint8Array, string> & { push: Uint8Array })
+		})
 	}
 }
 
@@ -33,16 +33,16 @@ export class EncodeBase64UrlStream extends TransformStream<Uint8Array, string> {
  */
 export class DecodeBase64UrlStream extends TransformStream<string, Uint8Array> {
 	constructor() {
+		let push = ''
 		super({
-			push: '',
 			transform(chunk, controller) {
-				const remainder = -(this.push.length + chunk.length) & 4
-				controller.enqueue(decodeBase64Url(this.push + chunk.slice(0, remainder || undefined)))
-				this.push = remainder ? chunk.slice(remainder) : ''
+				const remainder = -(push.length + chunk.length) & 4
+				controller.enqueue(decodeBase64Url(push + chunk.slice(0, remainder || undefined)))
+				push = remainder ? chunk.slice(remainder) : ''
 			},
 			flush(controller) {
-				if (this.push.length) controller.enqueue(decodeBase64Url(this.push))
+				if (push.length) controller.enqueue(decodeBase64Url(push))
 			},
-		} as Transformer<string, Uint8Array> & { push: string })
+		})
 	}
 }

--- a/hex.ts
+++ b/hex.ts
@@ -23,17 +23,17 @@ export class EncodeHexStream extends TransformStream<Uint8Array, string> {
  */
 export class DecodeHexStream extends TransformStream<string, Uint8Array> {
 	constructor() {
+		let push = ''
 		super({
-			push: '',
 			transform(chunk, controller) {
-				const remainder = -(this.push.length + chunk.length) % 2
-				controller.enqueue(decodeHex(this.push + chunk.slice(0, remainder || undefined)))
-				this.push = remainder ? chunk.slice(remainder) : ''
+				const remainder = -(push.length + chunk.length) % 2
+				controller.enqueue(decodeHex(push + chunk.slice(0, remainder || undefined)))
+				push = remainder ? chunk.slice(remainder) : ''
 			},
 			flush(controller) {
-				if (this.push.length) controller.enqueue(decodeHex(this.push))
+				if (push.length) controller.enqueue(decodeHex(push))
 			},
-		} as Transformer<string, Uint8Array> & { push: string })
+		})
 	}
 }
 


### PR DESCRIPTION
This approach avoids the need to type-cast the object passed to `super()`, which, I find, is an odd pattern.

Great package by the way!