### PR TITLE
chore: remove unnecessary `console.log()`

### DIFF
--- a/hex.ts
+++ b/hex.ts
@@ -36,5 +36,3 @@ export class DecodeHexStream extends TransformStream<string, Uint8Array> {
 		} as Transformer<string, Uint8Array> & { push: string })
 	}
 }
-
-console.log(decodeHex(''))


### PR DESCRIPTION
It seems this was left here by mistake. In case you didn't know, you can avoid this by enabling the [`no-console`](https://lint.deno.land/rules/no-console) lint rule.